### PR TITLE
App store inspired changes for the schema

### DIFF
--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -4,11 +4,11 @@
     "$schema": "http://json-schema.org/draft-04/hyper-schema",
     "type": "object",
     "properties": {
-        "name": {
+        "id": {
             "type": "string",
             "description": "Short name that acts as the project identifier"
         },
-        "full_name": {
+        "name": {
             "type": "string",
             "description": "Full proper name of the project"
         },
@@ -17,12 +17,32 @@
             "description": "The type of content in the repo",
             "enum": ["app", "docs", "policy"]
         },
-        "owner_type": {
-            "type": "string",
-            "description": "Describes whether a project team, working group/guild, etc. owns the repo",
-            "enum": ["guild", "working-group", "project"]
+        "owner": {
+          "organization": {
+              "type": "string",
+              "description": "Short name for the organization that owns the project"
+          },
+          "team": {
+            "type": {
+                "type": "string",
+                "description": "Describes whether a project team, working group/guild, etc. owns the repo",
+                "enum": ["guild", "working-group", "internal-project", "client-project"]
+            },
+            "id": {
+                "type": "string",
+                "description": "Short name that acts as the project identifier"
+            },
+            "leads": {
+              "type": "array",
+              "description": "People who are in charge of this project",
+              "items": {
+                  "$ref": "#/definitions/person"
+              },
+              "uniqueItems": true
+            }
+          },
         },
-        "parent": {
+        "parent_repo": {
             "type": "string",
             "description": "Name of the main project repo if this is a sub-repo; name of the working group/guild repo if this is a working group/guild subproject"
         },
@@ -45,14 +65,6 @@
             "type": "boolean",
             "default": false,
             "description": "Should be 'true' if the project has a continuous build"
-        },
-        "team": {
-            "type": "array",
-            "description": "Team members contributing to the project",
-            "items": {
-                "$ref": "#/definitions/person"
-            },
-            "uniqueItems": true
         },
         "partners": {
             "type": "array",
@@ -120,11 +132,9 @@
         },
         "contact": {
             "type": "array",
-            "description": "Email addresses of points-of-contact",
+            "description": "URLs for points-of-contact",
             "items": {
-              "type": "string",
-              "description": "Email address",
-              "format": "uri"
+              "$ref": "#/definitions/contact"
             },
             "uniqueItems": true
         }
@@ -211,6 +221,21 @@
                 "url": {
                     "type": "string",
                     "description": "URL for the link",
+                    "format": "uri"
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Anchor text for the link"
+                }
+            }
+        },
+        "contact": {
+            "type": "object",
+            "description": "Link to a project contact",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "URL for the link to ",
                     "format": "uri"
                 },
                 "text": {

--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -28,13 +28,8 @@
         },
         "stage": {
             "type": "string",
-            "enum": ["discovery", "alpha", "beta", "live"],
+            "enum": ["discovery", "alpha", "beta", "live", "sunset", "transfer", "end"],
             "description": "Maturity stage of the project"
-        },
-        "status": {
-            "type": "string",
-            "enum": ["active", "deprecated"],
-            "description": "Whether or not the project is actively maintained"
         },
         "description": {
             "type": "string",

--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -60,6 +60,14 @@
             "items": {"type": "string"},
             "uniqueItems": true
         },
+        "users": {
+            "type": "array",
+            "description": "Organizations or individuals who have adopted the project for their own use",
+            "items": {
+                "$ref": "#/definitions/user"
+            },
+            "uniqueItems": true
+        },
         "milestones": {
             "type": "array",
             "description": "Brief descriptions of significant project developments",
@@ -122,7 +130,7 @@
         }
     },
     "required": [
-        "name", "full_name", "stage", "team", "licenses", "owner_type", "status", "testable"
+        "name", "full_name", "stage", "team", "licenses", "owner_type", "testable"
     ],
     "definitions": {
         "person": {
@@ -140,6 +148,20 @@
                 "role": {
                     "type": "string",
                     "description": "Team member's role; leads should be designated as 'lead'"
+                }
+            }
+        },
+        "user": {
+            "type": "object",
+            "description": "Organizations or individuals who have adopted the project for their own use",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The name of the organization or individual"
+                },
+                "url": {
+                    "type": "string",
+                    "description": "A URL to the user's version of the project"
                 }
             }
         },

--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -57,7 +57,7 @@
         },
         "tags": {
             "type": "array",
-            "description": "Tags that describe the project or aspects of thr project",
+            "description": "Tags that describe the project or aspects of the project",
             "items": {"type": "string"},
             "uniqueItems": true
         },
@@ -140,7 +140,7 @@
         }
     },
     "required": [
-        "name", "full_name", "stage", "team", "licenses", "owner_type", "testable"
+        "id", "name", "stage", "team", "licenses", "owner_type", "testable"
     ],
     "definitions": {
         "person": {

--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -40,6 +40,12 @@
             "type": "string",
             "description": "Description of the project"
         },
+        "tags": {
+            "type": "array",
+            "description": "Tags that describe the project or aspects of thr project",
+            "items": {"type": "string"},
+            "uniqueItems": true
+        },
         "testable": {
             "type": "boolean",
             "default": false,


### PR DESCRIPTION
@melodykramer and I have a few proposed changes (we've had discussions in #7, #8, #9, and #10) that we'd like to make `.about.yml` data a bit more useful and model the kinds of things we'll need for other dashboards and projects.

Specifically, here are the things that have changed:
1. Add an array of tags that can be applied to the project
2. Add new stages, but removes the `status` key
3. Implement a notion of "users", who are people or orgs that have forked/cloned/installed our software and are using it
4. Change the ownership model to reflect 18F as a parent organization with smaller teams inside of it

cc @mbland, @gboone and @ultrasaurus - This is ready for review and totally open for suggestions. I thought it might be easier to have concrete discussions around a PR with an implementation of the schema.
