### PR TITLE
Add tag collection to schema

### DIFF
--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -40,6 +40,12 @@
             "type": "string",
             "description": "Description of the project"
         },
+        "tags": {
+            "type": "array",
+            "description": "Tags that describe the project or aspects of the project",
+            "items": {"type": "string"},
+            "uniqueItems": true
+        },
         "testable": {
             "type": "boolean",
             "default": false,


### PR DESCRIPTION
As described in #10, we want to add in a tag collection. This adds a tags key that should be an array of strings.
