### PR TITLE
Add users as a collection of adopters

### DIFF
--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -59,6 +59,14 @@
             "items": {"type": "string"},
             "uniqueItems": true
         },
+        "users": {
+            "type": "array",
+            "description": "Organizations or individuals who have adopted the project for their own use",
+            "items": {
+                "$ref": "#/definitions/user"
+            },
+            "uniqueItems": true
+        },
         "milestones": {
             "type": "array",
             "description": "Brief descriptions of significant project developments",
@@ -139,6 +147,20 @@
                 "role": {
                     "type": "string",
                     "description": "Team member's role; leads should be designated as 'lead'"
+                }
+            }
+        },
+        "user": {
+            "type": "object",
+            "description": "Organizations or individuals who have adopted the project for their own use",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The name of the organization or individual"
+                },
+                "url": {
+                    "type": "string",
+                    "description": "A URL to the user's version of the project"
                 }
             }
         },


### PR DESCRIPTION
Per issue #9 we want to be able to model a collection of individuals or organizations who have adopted our projects and started them up in their own environments.
