### PR TITLE
Remove status and add new stages

### DIFF
--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -31,11 +31,6 @@
             "enum": ["discovery", "alpha", "beta", "live", "sunset", "transfer", "end"],
             "description": "Maturity stage of the project"
         },
-        "status": {
-            "type": "string",
-            "enum": ["active", "deprecated"],
-            "description": "Whether or not the project is actively maintained"
-        },
         "description": {
             "type": "string",
             "description": "Description of the project"

--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -28,7 +28,7 @@
         },
         "stage": {
             "type": "string",
-            "enum": ["discovery", "alpha", "beta", "live"],
+            "enum": ["discovery", "alpha", "beta", "live", "sunset", "transfer", "end"],
             "description": "Maturity stage of the project"
         },
         "status": {


### PR DESCRIPTION
Per #8 we wanted to get rid of the “status” tag since it wasn’t
providing us value and was confusing in the context of being a sibling
of “stage”.

We have also said that the current list of stages isn't adequate to reflect our portfolio of projects.
