### PR TITLE
Use urls for points of contact instead of emails

### DIFF
--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -111,7 +111,7 @@
         },
         "contact": {
             "type": "array",
-            "description": "URLs for points-of-contact",
+            "description": "URIs for points-of-contact",
             "items": {
                 "$ref": "#/definitions/contact"
             },
@@ -200,7 +200,7 @@
             "properties": {
                 "url": {
                     "type": "string",
-                    "description": "URL for the link to ",
+                    "description": "URI for the link to ",
                     "format": "uri"
                 },
                 "text": {

--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -111,11 +111,9 @@
         },
         "contact": {
             "type": "array",
-            "description": "Email addresses of points-of-contact",
+            "description": "URLs for points-of-contact",
             "items": {
-              "type": "string",
-              "description": "Email address",
-              "format": "uri"
+                "$ref": "#/definitions/contact"
             },
             "uniqueItems": true
         }
@@ -188,6 +186,21 @@
                 "url": {
                     "type": "string",
                     "description": "URL for the link",
+                    "format": "uri"
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Anchor text for the link"
+                }
+            }
+        },
+        "contact": {
+            "type": "object",
+            "description": "Link to a project contact",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "URL for the link to ",
                     "format": "uri"
                 },
                 "text": {


### PR DESCRIPTION
We want to be able to have all sorts of method of getting in touch with the project, and some of those will be emails and some will be URLs. Contact has been changed to be an array of contact objects
