### PR TITLE
Adding the github description to the info pulled into the about.yml.

### DIFF
--- a/lib/about_yml/about.rb
+++ b/lib/about_yml/about.rb
@@ -55,7 +55,7 @@ module AboutYml
       result[collection][repo_name] = fetch_file_contents client, repo_name
       add_github_metadata result[collection][repo_name], repo
     rescue Octokit::NotFound
-      result['missing'] << repo.full_name unless collection == 'private'
+      result['missing'] << repo.full_name
     rescue StandardError => err
       write_error err, repo, result
     end

--- a/lib/about_yml/about.rb
+++ b/lib/about_yml/about.rb
@@ -36,16 +36,28 @@ module AboutYml
       SafeYAML.load Base64.decode64(about['content'])
     end
 
+    def self.write_error(err, repo, result)
+      $stderr.puts('Error while parsing .about.yml for ' \
+        "#{repo.full_name}:\n #{err}")
+      result['errors'] << { repo.full_name => err.message }
+    end
+
+    def self.add_github_metadata(result, repo)
+      result['github'] = {
+        'name' => repo.full_name,
+        'description' => repo.description,
+      }
+    end
+
     def self.collect_repository_data(repo, client, result)
       collection = (repo.private == true) ? 'private' : 'public'
       repo_name = repo.full_name
       result[collection][repo_name] = fetch_file_contents client, repo_name
+      add_github_metadata result[collection][repo_name], repo
     rescue Octokit::NotFound
-      result['missing'] << repo.full_name
+      result['missing'] << repo.full_name unless collection == 'private'
     rescue StandardError => err
-      $stderr.puts('Error while parsing .about.yml for ' \
-        "#{repo.full_name}:\n #{err}")
-      result['errors'] << {repo.full_name => err.message} 
+      write_error err, repo, result
     end
     private_class_method :collect_repository_data
 


### PR DESCRIPTION
Previously, the about_yml gem returned the raw about_yml file. Now it returns the about.yml file contents augmented by a `github` key that contains the repos `full_name` and `description`.
