### PR TITLE
Standardize URL descriptions

### DIFF
--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -223,7 +223,7 @@
             "properties": {
                 "url": {
                     "type": "string",
-                    "description": "URI for the link to ",
+                    "description": "URL for the link",
                     "format": "uri"
                 },
                 "text": {


### PR DESCRIPTION
This pull request standardizes the URL descriptions to 'URL for the link' for the sake of consistency.

It makes the following changes:
1. removes a trailing 'to ' and
2. updates 'URI' to 'URL'
