### PR TITLE
Adding a category to the link object to support multiple link types.

### DIFF
--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -220,7 +220,10 @@
                     "description": "Type of the link",
                     "enum": ["api", "process", "related"]
                 }
-            }
+            },
+            "required": [
+              "url"
+            ]
         },
         "contact": {
             "type": "object",

--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -109,6 +109,15 @@
             "format": "uri",
             "uniqueItems": true
         },
+        "api_links": {
+            "type": "array",
+            "description": "Links to project api artifacts",
+            "items": {
+                "$ref": "#/definitions/link"
+            },
+            "format": "uri",
+            "uniqueItems": true
+        },
         "links": {
             "type": "array",
             "description": "Links to project artifacts",

--- a/lib/about_yml/schema.json
+++ b/lib/about_yml/schema.json
@@ -109,15 +109,6 @@
             "format": "uri",
             "uniqueItems": true
         },
-        "api_links": {
-            "type": "array",
-            "description": "Links to project api artifacts",
-            "items": {
-                "$ref": "#/definitions/link"
-            },
-            "format": "uri",
-            "uniqueItems": true
-        },
         "links": {
             "type": "array",
             "description": "Links to project artifacts",
@@ -223,6 +214,11 @@
                 "text": {
                     "type": "string",
                     "description": "Anchor text for the link"
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Type of the link",
+                    "enum": ["api", "process", "related"]
                 }
             }
         },


### PR DESCRIPTION
As per 18F/dashboard#266, there should be a way to specify an API link in the about.yml file. This duplicates the structure of the links object to provide more flexibility.
