### PR TITLE
Enable run_about_yml_check to work in other repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ schema. To check your project's `.about.yml` file:
 $ about_yml_validate MY-PROJECT/.about.yml
 ```
 
+Alternatively, you can add the following to your `Rakefile` to tie
+`.about.yml` validation into your build process (this assumes that `Rakefile`
+and `.about.yml` are both in the top-level project directory):
+
+```ruby
+# Development-only tasks
+begin
+  require 'about_yml/tasks/check_about_yml'
+  task test: :run_about_yml_check
+rescue LoadError
+end
+```
+
 ### `about_yml_scrape`
 
 This program checks for an `.about.yml` file in every GitHub repository

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
+require_relative './lib/about_yml/tasks/check_about_yml'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
-load './lib/tasks/check_about_yml.rake'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
@@ -9,3 +9,4 @@ end
 
 desc 'Run .about.yml tests'
 task default: :test
+task test: :run_about_yml_check

--- a/go
+++ b/go
@@ -34,6 +34,7 @@ def_command :update_gems, 'Update Ruby gems' do |gems = []|
 end
 
 def_command :test, 'Execute automated tests' do |args = []|
+  exec_cmd 'bundle exec rake test'
   exec_cmd "bundle exec rspec #{args.join ' '}"
 end
 

--- a/lib/about_yml/tasks/check_about_yml.rb
+++ b/lib/about_yml/tasks/check_about_yml.rb
@@ -1,0 +1,20 @@
+require 'about_yml'
+require 'safe_yaml'
+
+desc 'Check your .about.yml file'
+task :run_about_yml_check do
+  project_dir = Rake.original_dir
+  about_file = File.join project_dir, '.about.yml'
+  unless File.exist? about_file
+    $stderr.puts "No .about.yml file found in #{project_dir}"
+    exit 1
+  end
+
+  about_data = SafeYAML.load_file about_file, safe: true
+  errors = ::AboutYml::AboutFile.validate_single_file about_data
+  unless errors.empty?
+    $stderr.puts(".about.yml contains the following validation errors:\n  " +
+      "#{errors.join("\n  ")}")
+    exit 1
+  end
+end

--- a/lib/tasks/check_about_yml.rake
+++ b/lib/tasks/check_about_yml.rake
@@ -1,7 +1,0 @@
-require 'rspec/core/rake_task'
-require_relative '../../spec/about_yml_file_spec.rb'
-
-desc 'Check your .about.yml file'
-RSpec::Core::RakeTask.new(:run_about_yml_check) do |t|
-  t.pattern = File.expand_path '../../../spec/about_yml_file_spec.rb', __FILE__
-end

--- a/spec/about_yml_file_spec.rb
+++ b/spec/about_yml_file_spec.rb
@@ -3,8 +3,8 @@ require_relative '../lib/about_yml'
 require 'rspec'
 require 'safe_yaml'
 
-RSpec.describe AboutYml::TemplateGenerator do
-  it 'generates a valid template' do
+RSpec.describe AboutYml::AboutFile do
+  it 'validates the .about.yml file against the schema' do
     filepath = File.expand_path('../../.about.yml', __FILE__)
     about_file = File.join filepath
     about_data = SafeYAML.load_file about_file, safe: true


### PR DESCRIPTION
@ertzeid This is a PR against your #56. I was able to take what you had there and figure out how to get it to work for other repos. Specifically, I added this to the `Gemfile` of my local 18F/team-api.18f.gov clone:

``` ruby
gem 'about_yml', path: '../about_yml'
```

And then in the `Rakefile`:

``` ruby
require 'about_yml/tasks/check_about_yml'
task test: :run_about_yml_check
```

Consequently, running `./go test` produces this:

```
.about.yml contains the following validation errors:
  The property '#/licenses' of type Array did not match the following type: object in schema 075cd37b-f2cc-50d9-aa8a-9664a012b9eb#
  The property '#/contact' of type String did not match the following type: array in schema 075cd37b-f2cc-50d9-aa8a-9664a012b9eb#
```

I've documented this in the `README` as well.
